### PR TITLE
fix: allow sending strings as encrypted replies in echo_client example

### DIFF
--- a/examples/echo_client.py
+++ b/examples/echo_client.py
@@ -215,8 +215,9 @@ class OmemoEchoClient(ClientXMPP):
         xep_0384: XEP_0384 = self["xep_0384"]
 
         if isinstance(reply, str):
+            reply_body = reply
             reply = self.make_message(mto=mto, mtype=mtype)
-            reply["body"] = reply
+            reply["body"] = reply_body
 
         reply.set_to(mto)
         reply.set_from(self.boundjid)


### PR DESCRIPTION
the `encrypted_reply` function in the echo client example accepts a Message or a string for the reply parameter.  But supplying a string caused an error because the variable name `reply` was being reused. This commit introduces a new variable to temporarily hold the reply body, so it can get sent.